### PR TITLE
Add automation for tests, linter, and static analysis

### DIFF
--- a/build
+++ b/build
@@ -36,6 +36,11 @@ function camelCase(string $string): string
     }, subject: $string);
 }
 
+function kebabCase(string $string): string
+{
+    return strtolower(preg_replace(pattern: '/([a-zA-Z])(?=[A-Z])/', replacement: '$1-', subject: $string));
+}
+
 function replaceInFile($search, $replace, $filename): void
 {
     file_put_contents(
@@ -379,11 +384,22 @@ file_put_contents(
 
 rename(from: 'stubs/Arch.php.stub', to: 'tests/Arch.php');
 rename(from: 'stubs/TestCase.php.stub', to: 'tests/TestCase.php');
+
 replaceInFile(
     search: [':vendorName', ':packageName'],
     replace: [$vendorName, $packageName],
     filename: 'tests/TestCase.php',
 );
+
+if ($testingFramework === 'PHPUnit') {
+    rename(from: 'stubs/run-tests.yml.stub', to: '.github/workflows/run-tests.yml');
+
+    replaceInFile(
+        search: [':phpVersion', ':laravelVersion'],
+        replace: [$phpVersion, $laravelVersion],
+        filename: '.github/workflows/run-tests.yml',
+    );
+}
 
 // Does the User want to use Pest?
 if ($testingFramework === 'Pest') {
@@ -401,6 +417,13 @@ if ($testingFramework === 'Pest') {
         filename: 'tests/Pest.php',
         data: "<?php\n\nuse $vendorName\\$packageName\\Tests\TestCase;\n\nuses(TestCase::class)->in(__DIR__);\n"
     );
+
+    rename(from: 'stubs/run-pest.yml.stub', to: '.github/workflows/run-pest.yml');
+    replaceInFile(
+        search: [':phpVersion', ':laravelVersion'],
+        replace: [$phpVersion, $laravelVersion],
+        filename: '.github/workflows/run-pest.yml',
+    );
 }
 
 // Does the User want to use Pint?
@@ -411,6 +434,8 @@ if (in_array(needle: 'Pint', haystack: $enabledFeatures)) {
             "laravel/pint" => "^1.0",
         ]
     );
+
+    rename(from: 'stubs/run-linter.yml.stub', to: '.github/workflows/run-linter.yml');
 }
 
 // Does the User want to use PHPStan and Larastan?
@@ -432,10 +457,17 @@ if (in_array(needle: 'PHPStan', haystack: $enabledFeatures)) {
     }
 
     rename(from: 'stubs/phpstan.neon.stub', to: 'phpstan.neon');
+    rename(from: 'stubs/static-analysis.yml.stub', to: '.github/workflows/static-analysis.yml');
 
     file_put_contents(
         filename: 'phpstan.neon',
         data: "includes: - ./vendor/nunomaduro/larastan/extension.neon\n\n".file_get_contents(filename: 'phpstan.neon')
+    );
+
+    replaceInFile(
+        search: [':phpVersion'],
+        replace: [$phpVersion],
+        filename: '.github/workflows/static-analysis.yml',
     );
 }
 
@@ -515,13 +547,13 @@ $composerDataStructure['extra'] = [
 addComposerData(data: $composerDataStructure);
 
 /**
- |--------------------------------------------------------------------------
- | Install the dependencies
- |--------------------------------------------------------------------------
- |
- | Everything is done; now it's time to install the dependencies.
- |
-*/
+ * |--------------------------------------------------------------------------
+ * | Install the dependencies
+ * |--------------------------------------------------------------------------
+ * |
+ * | Everything is done; now it's time to install the dependencies.
+ * |
+ */
 $confirmInstall = confirm(label: 'Are you ready to install the dependencies?');
 
 if ($confirmInstall) {
@@ -529,8 +561,13 @@ if ($confirmInstall) {
 
     run(command: 'composer update --quiet --no-interaction');
 
-    // The README is cleared so the User can use it to write their own documentation
-    file_put_contents(filename: 'README.md', data: '');
+    rename(from: 'stubs/README.md.stub', to: 'README.md');
+
+    replaceInFile(
+        search: [':username', ':packageName', ':laravelVersion', ':which-test'],
+        replace: [$username, kebabCase($packageName), $laravelVersion, $testingFramework === 'Pest' ? 'pest' : 'tests'],
+        filename: 'README.md',
+    );
 }
 
 info(message: 'Installation complete! You\'re all set to start building your package.');

--- a/stubs/README.md.stub
+++ b/stubs/README.md.stub
@@ -1,0 +1,5 @@
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/:username/:packageName?color=rgb%2856%20189%20248%29&label=release&style=for-the-badge)](https://packagist.org/packages/:username/:packageName)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/:username/:packageName/run-:which-test.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/:username/:packageName/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![Total Downloads](https://img.shields.io/packagist/dt/:username/:packageName.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/:username/:packageName)
+![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/:username/:packageName/php?color=rgb%28165%20180%20252%29&logo=php&logoColor=rgb%28165%20180%20252%29&style=for-the-badge)
+![Laravel Version](https://img.shields.io/badge/laravel-^:laravelVersion-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)

--- a/stubs/run-linter.yml.stub
+++ b/stubs/run-linter.yml.stub
@@ -1,0 +1,20 @@
+name: "Run Linter"
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint with Pint
+        uses: aglipanci/laravel-pint-action@2.3.0
+
+      - name: Commit linted files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "fix: Files linted with Pint"

--- a/stubs/run-pest.yml.stub
+++ b/stubs/run-pest.yml.stub
@@ -1,0 +1,35 @@
+name: "Run Pest"
+on: pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ :phpVersion ]
+        laravel: [ :laravelVersion ]
+        stability: [ prefer-lowest, prefer-stable ]
+
+    name: "PHP: v${{ matrix.php }} [${{ matrix.stability }}]"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Install dependencies
+        run: |
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+      - name: Execute tests
+        run: vendor/bin/pest

--- a/stubs/run-tests.yml.stub
+++ b/stubs/run-tests.yml.stub
@@ -1,0 +1,35 @@
+name: "Run Tests"
+on: pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ :phpVersion ]
+        laravel: [ :laravelVersion ]
+        stability: [ prefer-lowest, prefer-stable ]
+
+    name: "PHP: v${{ matrix.php }} [${{ matrix.stability }}]"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Install dependencies
+        run: |
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/stubs/static-analysis.yml.stub
+++ b/stubs/static-analysis.yml.stub
@@ -1,0 +1,26 @@
+name: "Run Static Analysis"
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+
+jobs:
+  phpstan:
+    name: phpstan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: :phpVersion
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan --error-format=github


### PR DESCRIPTION
Added support for automated tests, linter, and static analysis through GitHub Actions. This includes creating stubs for different action workflows and renaming them during the build process. The workflows are configured based on the user's selected testing framework (PHPUnit or Pest) and desired tools(Pint and PHPStan). A new kebabCase function was introduced to format the package name in README.md, which is also dynamically generated from a stub. These changes aim to facilitate and automate the package testing, linting, and static analysis processes, improving the workflow for users.