### PR TITLE
Add new community standard file

### DIFF
--- a/build
+++ b/build
@@ -605,6 +605,7 @@ if ($confirmInstall) {
     spin(callback: function () use ($username, $packageName, $laravelVersion, $testingFramework) {
         run(command: 'composer update --quiet --no-interaction');
 
+        rename(from: 'stubs/PULL_REQUEST_TEMPLATE.md.stub', to: '.github/PULL_REQUEST_TEMPLATE.md');
         rename(from: 'stubs/README.md.stub', to: 'README.md');
 
         replaceInFile(

--- a/stubs/PULL_REQUEST_TEMPLATE.md.stub
+++ b/stubs/PULL_REQUEST_TEMPLATE.md.stub
@@ -1,0 +1,27 @@
+## Description
+
+Please include a summary of what this PR aims to accomplish. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Related Issues and Pull Requests
+
+- Issue #...
+- PR #...
+
+## Testing
+
+Please provide a passing test where possible. This package uses [PestPHP](https://pestphp.com)
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have made corresponding changes to the documentation [OPTIONAL]


### PR DESCRIPTION
This PR adds a `PULL_REQUEST_TEMPLATE` file to `.github` folder.

This is a recommended file to have in the repo for when a User is submitting a PR. This will check it off in the repo's community standards page.